### PR TITLE
Fix async conversation flows and add missing APIs

### DIFF
--- a/app/api/dependencies.py
+++ b/app/api/dependencies.py
@@ -300,7 +300,7 @@ def require_role(required_role: str) -> Callable:
         memory_service: MemoryService = Depends(get_memory_service),
     ) -> Dict[str, str]:
         user_id = user_info.get("user_id")
-        if not user_id:
+        if not user_id or user_id == "anonymous":
             raise HTTPException(status_code=401, detail="Not authenticated")
         user_profile = await memory_service.get_user_profile(user_id)
         if not user_profile or user_profile.role != required_role:

--- a/app/api/routes/conversations.py
+++ b/app/api/routes/conversations.py
@@ -43,9 +43,15 @@ async def create_thread(room_id: str, thread_data: ConversationThreadCreate, use
     return convo_service.create_thread(room_id, user_id, thread_data)
 
 @router.get("/rooms/{room_id}/threads", response_model=List[ConversationThread])
-async def list_threads(room_id: str, query: Optional[str] = None, pinned: Optional[bool] = None, archived: Optional[bool] = None, convo_service: ConversationService = Depends(get_conversation_service)):
+async def list_threads(
+    room_id: str,
+    query: Optional[str] = None,
+    pinned: Optional[bool] = None,
+    archived: Optional[bool] = None,
+    convo_service: ConversationService = Depends(get_conversation_service),
+):
     # Note: The service layer will need to be updated to handle generic room_id
-    return convo_service.get_threads_by_room(room_id, query, pinned, archived)
+    return await convo_service.get_threads_by_room(room_id, query, pinned, archived)
 
 @router.post("/threads/{thread_id}/messages", response_model=Dict[str, str], dependencies=[Depends(check_budget)])
 async def create_message(thread_id: str, request_data: CreateMessageRequest, user_info: Dict[str, Any] = AUTH_DEPENDENCY, convo_service: ConversationService = Depends(get_conversation_service)):

--- a/app/api/routes/messages.py
+++ b/app/api/routes/messages.py
@@ -1,8 +1,9 @@
 """
 Message-related API endpoints
 """
-import logging
+import inspect
 import json
+import logging
 import re
 from datetime import datetime
 from typing import Any, Dict, Optional, List
@@ -52,6 +53,13 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="", tags=["messages"])
 
 # --- V2 Fact Extraction/Retrieval Helpers ---
+
+
+async def _maybe_get_room(storage_service: StorageService, room_id: str):
+    room = storage_service.get_room(room_id)
+    if inspect.isawaitable(room):
+        room = await room
+    return room
 
 async def _handle_fact_extraction(
     user_fact_service: UserFactService,
@@ -341,7 +349,7 @@ async def send_message(
         # Fact extraction already executed above (or scheduled via background tasks on failure).
         
         # --- Original Intent/Action Processing Logic ---
-        current_room = storage_service.get_room(room_id)
+        current_room = await _maybe_get_room(storage_service, room_id)
         if current_room and current_room.type == RoomType.REVIEW:
             # ... existing review room logic ...
             pass

--- a/tests/e2e/test_conversation_system.py
+++ b/tests/e2e/test_conversation_system.py
@@ -428,7 +428,7 @@ class TestConversationServiceIntegration:
         assert thread.title == "Integration Test Thread"
         
         # Get threads by subroom
-        retrieved_threads = service.get_threads_by_room(room_id)
+        retrieved_threads = asyncio.run(service.get_threads_by_room(room_id))
         assert len(retrieved_threads) > 0
         retrieved_thread = retrieved_threads[0]
         assert retrieved_thread.title == thread.title
@@ -464,7 +464,7 @@ class TestConversationServiceIntegration:
             assert success is True
             
             # Verify deletion
-            remaining_threads = service.get_threads_by_room(room_id)
+            remaining_threads = asyncio.run(service.get_threads_by_room(room_id))
             assert len(remaining_threads) == 0
         
         print("✅ ConversationService CRUD operations test passed")


### PR DESCRIPTION
## Summary
- ensure the conversation thread listing endpoint awaits the async service and update the integration test helpers accordingly
- implement `MemoryService.get_context` and teach message/review routes to tolerate async storage lookups
- add POST `/api/search` and nested `/api/rooms/{room_id}/reviews` endpoints while tightening admin auth for anonymous requests

## Testing
- pytest tests/e2e/test_conversation_system.py::TestConversationServiceIntegration::test_conversation_service_crud_operations -q *(fails: database connection refused in container)*

------
https://chatgpt.com/codex/tasks/task_e_68cc6d480b108326812ebde3ca59edae